### PR TITLE
Don't piggyback require 'socket'; load the library in Nscaoutput.initialize

### DIFF
--- a/lib/fluent/plugin/out_nsca.rb
+++ b/lib/fluent/plugin/out_nsca.rb
@@ -96,6 +96,7 @@ module Fluent
     private
     def initialize
       super
+      require 'socket'
       require 'send_nsca'
     end
 

--- a/test/plugin/test_out_nsca.rb
+++ b/test/plugin/test_out_nsca.rb
@@ -2,7 +2,6 @@
 # vim: et sw=2 sts=2
 
 require 'helper'
-require 'socket'
 require 'send_nsca'
 
 class NscaOutputTest < Test::Unit::TestCase
@@ -229,6 +228,8 @@ class NscaOutputTest < Test::Unit::TestCase
     expected_first = [
       'monitor.example.com', 4242, 'aoxomoxoa', 'app.example.org', 'ddos_monitor', 2, 'possible attacks'
     ]
+
+    require 'socket'
     expected_second = [
       'monitor.example.com', 4242, 'aoxomoxoa', Socket.gethostname, 'ddos_monitor', 2, 'possible attacks'
     ]


### PR DESCRIPTION
The current implementation does not require 'socket', so it is piggybacking on fluentd or other plugins. That is not good behavior.

This pull request have the implementation load the library on its own.
